### PR TITLE
Added Post Preview styling for Decap

### DIFF
--- a/public/admin/styles.css
+++ b/public/admin/styles.css
@@ -1,0 +1,127 @@
+:root {
+  --primary: hsl(80, 90%, 55%);
+  --primaryLight: hsl(80, 60%, 40%);
+  --secondary: #001f3f;
+  --secondaryLight: #001f3f;
+  --headerColor: #1a1a1a;
+  --bodyTextColor: #4e4b66;
+  --bodyTextColorWhite: #fafbfc;
+
+  /* 13px - 16px */
+  --topperFontSize: clamp(0.8125rem, 1.6vw, 1rem);
+  /* 31px - 49px */
+  --headerFontSize: clamp(1.9375rem, 3.9vw, 3.0625rem);
+  --bodyFontSize: 1rem;
+
+  /* 60px - 100px top and bottom */
+  --sectionPadding: clamp(3.75rem, 7.82vw, 6.25rem) 1rem;
+}
+
+.frame-content {
+  font-family: 'Roboto', sans-serif;
+  line-height: 1.6em;
+}
+
+.frame-content h1,
+.frame-content h2,
+.frame-content h3,
+.frame-content h4,
+.frame-content h5,
+.frame-content h6 {
+  font-family: 'Roboto', sans-serif;
+  color: var(--headerColor);
+}
+
+.frame-content img {
+  max-width: 100%;
+}
+
+.frame-content .blog {
+  padding: 2rem;
+  max-width: 48rem;
+  margin-inline: auto;
+}
+
+.frame-content .blog .title {
+  margin-top: 40px;
+}
+
+.frame-content .blog .cover {
+  border-radius: 0.5em;
+  min-width: 100%;
+  height: clamp(200px, 30vw, 400px);
+  margin-bottom: 50px;
+  object-fit: cover;
+}
+
+.frame-content .blog .metadata {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 50px;
+  color: var(--bodyTextColor);
+}
+
+.frame-content .blog .metadata .author {
+  margin: 0;
+  font-size: 0.875rem;
+}
+
+.frame-content .blog .metadata .dot {
+  display: block;
+  width: 3px;
+  height: 3px;
+  background-color: var(--primary);
+  border-radius: 50%;
+  margin-bottom: 1px;
+}
+
+.frame-content .blog .metadata .date {
+  font-size: 0.875rem;
+}
+
+.frame-content .blog .divider {
+  margin-top: 0;
+  margin-bottom: 1.5625em;
+  background-color: #a2a0a0;
+}
+
+.frame-content .blog .markdown {
+  margin-top: 3rem;
+  max-width: 80ch;
+}
+
+.frame-content .blog .markdown h1,
+.frame-content .blog .markdown h2,
+.frame-content .blog .markdown h3,
+.frame-content .blog .markdown h4,
+.frame-content .blog .markdown h5,
+.frame-content .blog .markdown h6 {
+  color: var(--headerColor);
+}
+
+.frame-content .blog .markdown a {
+  color: var(--bodyTextColor);
+}
+
+.frame-content .blog .markdown a:hover {
+  color: var(--primary);
+  text-decoration-color: var(--primary);
+}
+
+.frame-content
+  .blog
+  .markdown
+  *:not(pre *, .admonition *, details *, blockquote *, span, a, h1, h2, h3, h4, h5, h6) {
+  color: var(--bodyTextColor);
+}
+
+.frame-content .blog .markdown pre {
+  padding: 1rem;
+  margin: 1rem 0;
+  background-color: #24292e;
+  color: #e1e4e8 !important;
+  overflow-x: auto;
+  border-radius: 0.5em;
+}

--- a/src/pages/admin.astro
+++ b/src/pages/admin.astro
@@ -10,5 +10,45 @@
 	<body>
 		<!-- Decap CMS script -->
 		<script is:inline src="https://unpkg.com/decap-cms@^3.1.2/dist/decap-cms.js"></script>
+		<script is:inline>
+      var BlogPreview = createClass({
+        render: function () {
+          const data = this.props.entry.get("data").toJS();
+
+          const title = data.title;
+          const author = data.author;
+          const date = typeof data.date === "string" ? new Date(data.date) : data.date;
+          let formattedDate = "";
+          if (date) {
+            formattedDate = Intl.DateTimeFormat("en-US", {
+              month: "long",
+              day: "numeric",
+              year: "numeric",
+            }).format(date);
+          }
+          const coverImage = data.image;
+          const cover = this.props.getAsset(coverImage);
+
+          return h(
+            "div",
+            { className: "blog" },
+            h("h1", { className: "title" }, title),
+            h(
+              "div",
+              { className: "metadata" },
+              h("span", { className: "author" }, author),
+							h("span", { className: "dot"}),
+              h("span", { className: "date" }, formattedDate),
+            ),
+            h("img", { src: cover.toString(), className: "cover" }),
+						h("hr", { className: "divider" }),
+            h("div", { className: "markdown" }, this.props.widgetFor("body")),
+          );
+        },
+      });
+
+      CMS.registerPreviewTemplate("blog", BlogPreview);
+      CMS.registerPreviewStyle("/admin/styles.css");
+    </script>
 	</body>
 </html>


### PR DESCRIPTION
# Decap Preview Styling
This change adds styling to the blog preview panel for Decap CMS. You can find the docs [here](https://decapcms.org/docs/customization/). There are important things to note I came across while making this.

### Styling
- You can only load a `.css` file for styling the preview. There's supposedly a way to use `.less` [here](https://decapcms.org/docs/customization/#raw-css-in-registerpreviewstyle), but it uses webpack and the documentation is poor.
- For some reason, only on deployment, css nesting does not work. Styles will only load if they are not nested 😠. 
- I'm fairly confident the fonts work by adding them into the `styles.css`, I can see them passed through into the source from the `/public` folder, but it should be tested further.
- The styles aren't perfectly one-to-one. It's definitely worth going in and modifying it to cover all the bases I missed.
- I haven't found a way to pull the styles from `root.less` directly so unless someone else can find something I think SOP should just be dropping in the fonts and `:root` css variables at the top of `styles.css` when they're done theming. The rest of the styles should use the css vars to populate correctly.

### DOM
- In the `admin.astro` page file there is a rudimentary react script that decap is able to use. It looks rough but this is what the [docs ](https://decapcms.org/docs/customization/#registerpreviewtemplate) say to do.
- The `h` function is shorthand for `React.createElement`, and the `BlogPreview` is an old school React class component.
- You can do some funky things with this script that are not intuitive, I would highly recommend leaving this as is unless you have React experience.
- If someone is expanding their CMS to include more collections, this component has access to basically all CMS data, it's just very convoluted in how to access it and how that data changes as the component updates. If anyone needs help with this in the future feel free to ask.

It's also always worth checking everything works **locally** and **deployed**, for both **existing** and **new entries**. This is fragile and changing things can break it in ways you won't expect.